### PR TITLE
Change Site's heading: Qualitic Maturity Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
-# Qualitic Community
+# Qualitic Maturity Model
 
-Qualitic is about developing successful quality software.
+Qualitic Maturity Model is about developing successful quality software respecting a set of clear rules.  
+It is a new approach to measure, guide, and empower the quality of the product development team.
+
+You can see [Qualitic Maturity Model](MATURITY_MODEL.md).
 
 ## Introduction
 
 We are committed to sharing artifacts, procedures, and best practices with each other.
-
-## Maturity Model
-
-Qualitic Maturity model is a new approach to measure, guide and empower the quality of the product development team.
-
-You can see [Qualitic Maturity Model](MATURITY_MODEL.md).
 
 ## Contribution
 


### PR DESCRIPTION
The "Qualitic Community" was not an appropriate title for the page. Since its core mission is to introduce the maturity model, not the whole community.