### PR TITLE
Shorten the title tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ plugins:
 
 remote_theme: chrisrhymes/bulma-clean-theme@v.0.12
 
-title: "A new approach to measure, guide, and empower the dev team."
+title: "A new approach to achieve quality"
 description: >
   Qualitic Maturity Model is about developing successful quality software respecting a set of clear rules. 
   It is a new approach to measure, guide, and empower the quality of the product development team.


### PR DESCRIPTION
It was reported - by a SEO tool - that the title is too long.