### PR TITLE
Shorten the description meta tag

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,9 +5,7 @@ plugins:
 remote_theme: chrisrhymes/bulma-clean-theme@v.0.12
 
 title: "A new approach to achieve quality"
-description: >
-  Qualitic Maturity Model is about developing successful quality software respecting a set of clear rules. 
-  It is a new approach to measure, guide, and empower the quality of the product development team.
+description: Qualitic Maturity Model is a new approach to measure, guide, and empower the quality of the product development team, with respect to a set of clear rules.
 defaults:
   -
     scope:


### PR DESCRIPTION
It was reported - by a SEO tool - that the title is too long.