### PR TITLE
Update theme version

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ plugins:
   - jekyll-relative-links
   - jekyll-sitemap
 
-remote_theme: chrisrhymes/bulma-clean-theme@v.0.12
+remote_theme: chrisrhymes/bulma-clean-theme@v0.12
 
 title: "A new approach to achieve quality"
 description: Qualitic Maturity Model is a new approach to measure, guide, and empower the quality of the product development team, with respect to a set of clear rules.


### PR DESCRIPTION
The version tag of Bulma theme had typo, which is now fixed and we as
users should point to the new tag.

For more details, see: https://github.com/chrisrhymes/bulma-clean-theme/issues/110