### PR TITLE
Fix hero image link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,5 @@ defaults:
       path: ""
     values:
       menubar_toc: true
-      hero_image: /assets/img/hero-background.webp
+      hero_image: https://media.githubusercontent.com/media/qualiticcommunity/qualiticcommunity.github.io/master/assets/img/hero-background.webp
       title: Qualitic Maturity Model

--- a/assets/img/hero-background.webp
+++ b/assets/img/hero-background.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:550b72228e6eed0fa15f37bebe04dc9168e064b9e5d82d1d141edad0b51e2c49
-size 151884
+oid sha256:287ae7f866f5ade9e80ceb37ffc418344e29ae9ce8b69d81c15f3d6b5e7d4ef3
+size 18882


### PR DESCRIPTION
Local relative link doesn't work with LFS, since GitHub pages doesn't
support git LFS.
Related issue: https://github.com/git-lfs/git-lfs/issues/1342