### PR TITLE
Sync maturity item titles with the catalog

### DIFF
--- a/catalog/build_ci/B002.md
+++ b/catalog/build_ci/B002.md
@@ -3,7 +3,7 @@
 | **Code**           | **B002** |
 | :--                | :--      |
 | **Title**          | A specific code style is enforced for main programming languages |
-| **Description**    | A agreed code style exists for each of main programming languages. Also, some procedures prevent merging inconsistent code style. |
+| **Description**    | An agreed code style exists for each of main programming languages. Also, some procedures prevent merging inconsistent code style. |
 | **Maturity Level** | [Level 2](/levels#level-2) |
 | **Possible Implementations** | Use tools like [Checkstyle](https://checkstyle.sourceforge.io/). |
 | **Evaluation**     | |

--- a/catalog/delivery/D004.md
+++ b/catalog/delivery/D004.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **D004** |
 | :--                | :--      |
-| **Title**          | Deployment frequency is on-demand (multiple deploys per day) |
+| **Title**          | Deployment is on-demand (multiple deploys per day) |
 | **Description**    | For the primary application or service, the code can be deployed on-demand. |
 | **Maturity Level** | [Level 5](/levels#level-5) |
 | **Possible Implementations** | |

--- a/catalog/environment/E008.md
+++ b/catalog/environment/E008.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **E008** |
 | :--                | :--      |
-| **Title**          | Data migration is tested |
+| **Title**          | Data migrations are tested |
 | **Description**    | Data migration validation is compulsory after upgrading process, for at least one environment. |
 | **Maturity Level** | [Level 5](/levels#level-5) |
 | **Possible Implementations** | |

--- a/catalog/environment/E010.md
+++ b/catalog/environment/E010.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **E010** |
 | :--                | :--      |
-| **Title**          | Same process (scripts) to deploy to every environment. |
+| **Title**          | Same process (scripts) to deploy to every environment |
 | **Description**    | Same process, tools and scripts are used for deploying the application to different environments. |
 | **Maturity Level** | [Level 3](/levels#level-3) |
 | **Possible Implementations** | |

--- a/catalog/test/T001.md
+++ b/catalog/test/T001.md
@@ -3,7 +3,7 @@
 | **Code**           | **T001** |
 | :--                | :--      |
 | **Title**          | Test coverage is measured at the [commit stage](/QMM-in-detail#commit-stage) |
-| **Description**    | |
+| **Description**    | 	Setup test coverage tool on commit stage tests. |
 | **Maturity Level** | [Level 1](/levels#level-1) |
-| **Possible Implementations** | Setup test coverage tool on commit stage tests.<br/>Use [Jacoco](https://www.jacoco.org/jacoco/) for java.<br/>Use [GoogleTest](https://github.com/google/googletest) for cpp. |
+| **Possible Implementations** | Use [Jacoco](https://www.jacoco.org/jacoco/) for java.<br/>Use [GoogleTest](https://github.com/google/googletest) for cpp. |
 | **Evaluation**     | Coverage is being calculated in each running test on CI. |

--- a/catalog/test/T004.md
+++ b/catalog/test/T004.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **T004** |
 | :--                | :--      |
-| **Title**          | Commit Stage Test Coverage > 50%. |
+| **Title**          | Commit stage test coverage > 50% |
 | **Description**    | Commit stage test coverage on source (excluding tests themselves) is greater than 50%. |
 | **Maturity Level** | [Level 4](/levels#level-4) |
 | **Possible Implementations** | Use Sonarqube to set a coverage gate. |

--- a/catalog/test/T014.md
+++ b/catalog/test/T014.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **T014** |
 | :--                | :--      |
-| **Title**          | "Requirement - Acceptance Test" mapping coverage > 20%. |
+| **Title**          | "Requirement - Acceptance Test" mapping coverage > 20% |
 | **Description**    | [See here](../../docs/requirement-test-mapping)  |
 | **Maturity Level** | [Level 4](/levels#level-4) |
 | **Possible Implementations** | |

--- a/catalog/test/T015.md
+++ b/catalog/test/T015.md
@@ -2,7 +2,7 @@
 
 | **Code**           | **T015** |
 | :--                | :--      |
-| **Title**          | "Requirement - Acceptance Test" mapping coverage > 50%. |
+| **Title**          | "Requirement - Acceptance Test" mapping coverage > 50% |
 | **Description**    | [See here](../../docs/requirement-test-mapping) |
 | **Maturity Level** | [Level 5](/levels#level-5) |
 | **Possible Implementations** | |

--- a/levels.md
+++ b/levels.md
@@ -4,10 +4,10 @@ This is what we use as quality maturity levels.
 ## Level 1
 
 | **Item**          | **Description** |
-| :--                | :--             |
-| **[T001](catalog/test/T001)** | Measure Test Coverage On Commit Stage. |
-| **[B001](catalog/build_ci/B001)** | All CI/CD scripts are in VC (CI Config in Code). |
-| **[T016](catalog/test/T016)** | No Release with Red Tests. |
+| :--               | :--             |
+| **[T001](catalog/test/T001)** | Test coverage is measured at the [commit stage](/QMM-in-detail#commit-stage) |
+| **[B001](catalog/build_ci/B001)** | All CI/CD scripts are kept in version control |
+| **[T016](catalog/test/T016)** | No release with red tests |
 
 ---
 
@@ -15,57 +15,57 @@ This is what we use as quality maturity levels.
 
 | **Item**          | **Description** |
 | :--                | :--             |
-| **[T002](catalog/test/T002)** | Commit Stage Test Coverage > 10% (At Least Daily). |
-| **[T007](catalog/test/T007)** | Classify Tests as Commit, Acceptance, and Performance. |
-| **[T011](catalog/test/T011)** | Acceptance Tests For at Least One Feature Upon Main Use Cases (Fully Automated in CI Script). |
-| **[B002](catalog/build_ci/B002)** | Enforcing a Specific Code Style for Main Programming Languages. |
-| **[B004](catalog/build_ci/B004)** | Prevent Compiler Warning. |
-| **[E001](catalog/environment/E001)** | All Direct External Dependencies for The Software Product Are Specified using Fixed Versions in Version Control and also Managed with Tools/Scripts in Version Control. |
-| **[E012](catalog/environment/E012)** | Do Not Store Your Secrets in Your Version Control. |
-| **[D001](catalog/delivery/D001)** |Deployment Frequency is Once Per Month. |
-| **[D005](catalog/delivery/D005)** | Lead Time for Changes is Less Than Six Months. |
-| **[D009](catalog/delivery/D009)** | Time to Restore Service is Less Than One Month. |
-| **[D013](catalog/delivery/D013)** | Change Failure Rate Less Than 60 Percent. |
+| **[T002](catalog/test/T002)** | Commit stage test coverage > 10% |
+| **[T007](catalog/test/T007)** | Classify tests as commit, acceptance, and performance |
+| **[T011](catalog/test/T011)** | There are acceptance tests for at least one feature upon main use cases |
+| **[B002](catalog/build_ci/B002)** | A specific code style is enforced for main programming languages |
+| **[B004](catalog/build_ci/B004)** | Compiler warnings are prevented |
+| **[E001](catalog/environment/E001)** | All direct external dependencies for the software product are specified using fixed versions in version control and also managed with tools/scripts in version control |
+| **[E012](catalog/environment/E012)** | Secrets are not stored in version control |
+| **[D001](catalog/delivery/D001)** | Deployment frequency is once per month |
+| **[D005](catalog/delivery/D005)** | Lead time for changes is less than six months |
+| **[D009](catalog/delivery/D009)** | Time to restore service is less than one month |
+| **[D013](catalog/delivery/D013)** | Change failure rate is less than 60% |
 
 ---
 
 ## Level 3
 
 | **Item**          | **Description** |
-| :--                | :--             |
-| **[T003](catalog/test/T003)** | Commit Stage Test Coverage > 50%. |
-| **[B005](catalog/build_ci/B005)** | Actively Use Available Analysis Tools On New Code As Submit Gate (50% of sonar-way, Incremental, Zero Issue). |
-| **[T012](catalog/test/T012)** | Acceptance Tests For Each New Feature. |
-| **[T013](catalog/test/T013)** | Requirement - Acceptance Test Mapping > 5%. |
-| **[E002](catalog/environment/E002)** | Automated Application Deployment From Scratch. |
-| **[E003](catalog/environment/E003)** | Automated Application Upgrade. |
-| **[E013](catalog/environment/E013)** | All Configuration In Version Control & All Production Configs From Version Control. |
-| **[E006](catalog/environment/E006)** | Data Is Migrated Using Versioned Script Only. |
-| **[D002](catalog/delivery/D002)** | Deployment Frequency is Once Per Week. |
-| **[D006](catalog/delivery/D006)** | Lead Time for Changes is Less Than One Month. |
-| **[D010](catalog/delivery/D010)** | Time to Restore Service is Less Than One Week. |
-| **[D014](catalog/delivery/D014)** | Change Failure Rate Is Less Than 45 Percent. |
-| **[E010](catalog/environment/E010)** | Same Process (scripts) To Deploy To Every Environment. |
+| :--               | :--             |
+| **[T003](catalog/test/T003)** | Commit stage test coverage > 20% |
+| **[B005](catalog/build_ci/B005)** | Available analysis tools on new code are actively used, as submit gate (50% sonar-way, zero issue, incremental) |
+| **[T012](catalog/test/T012)** | There are acceptance tests for each new feature |
+| **[T013](catalog/test/T013)** | "Requirement - Acceptance Test" mapping coverage > 5% |
+| **[E002](catalog/environment/E002)** | Automated application deployment from scratch |
+| **[E003](catalog/environment/E003)** | Automated application upgrade |
+| **[E013](catalog/environment/E013)** | All configuration in version control and all production configs from version control |
+| **[E006](catalog/environment/E006)** | Data is migrated using versioned script only |
+| **[D002](catalog/delivery/D002)** | Deployment frequency is once per week |
+| **[D006](catalog/delivery/D006)** | Lead time for changes is less than one month |
+| **[D010](catalog/delivery/D010)** | Time to restore service is less than one week |
+| **[D014](catalog/delivery/D014)** | Change failure rate is less than 45% |
+| **[E010](catalog/environment/E010)** | Same process (scripts) to deploy to every environment |
 
 ---
 
 ## Level 4
 
 | **Item**          | **Description** |
-| :--                | :--             |
-| **[T004](catalog/test/T004)** | Commit Stage Test Coverage > 60%. |
-| **[T014](catalog/test/T014)** | Requirement - Acceptance Test Mapping > 20%. |
-| **[B006](catalog/build_ci/B006)** | Actively Use Available Analysis Tools (80% sonar-way). |
-| **[B007](catalog/build_ci/B007)** | Build Environment Can Be Automatically Created From Version Control. |
-| **[B008](catalog/build_ci/B008)** | No manual configuration of CI/CD agent machines. |
-| **[E004](catalog/environment/E004)** | Automated Infrastructure Provisioning From Scratch. |
-| **[E007](catalog/environment/E007)** | Automated Data Migration While Deploying. |
-| **[E005](catalog/environment/E005)** | Automated Infrastructure Upgrade. |
-| **[E014](catalog/environment/E014)** | All Transitive Dependency Versions of Direct External Dependencies (related to item E001) Should be Defined. |
-| **[D003](catalog/delivery/D003)** | Deployment Frequency Is Once Per Day. |
-| **[D007](catalog/delivery/D007)** | Lead Time For Changes Is Less Than One Day. |
-| **[D011](catalog/delivery/D011)** | Time To Restore Service Is Less Than One Day. |
-| **[D015](catalog/delivery/D015)** | Change Failure Rate Is Less Than 15 Percent. |
+| :--               | :--             |
+| **[T004](catalog/test/T004)** | Commit stage test coverage > 50% |
+| **[T014](catalog/test/T014)** | "Requirement - Acceptance Test" mapping coverage > 20% |
+| **[B006](catalog/build_ci/B006)** | Available analysis tools are actively used on new code (80% of sonar-way) |
+| **[B007](catalog/build_ci/B007)** | Build environment can be automatically created from version control |
+| **[B008](catalog/build_ci/B008)** | No manual configuration of CI/CD agent machines |
+| **[E004](catalog/environment/E004)** | Automated infrastructure provisioning from scratch |
+| **[E007](catalog/environment/E007)** | Automated data migration while deploying |
+| **[E005](catalog/environment/E005)** | Automated infrastructure upgrade |
+| **[E014](catalog/environment/E014)** | All transitive dependency versions are defined |
+| **[D003](catalog/delivery/D003)** | Deployment frequency is once per day |
+| **[D007](catalog/delivery/D007)** | Lead time for changes is less than one week |
+| **[D011](catalog/delivery/D011)** | Time to restore service is less than one day |
+| **[D015](catalog/delivery/D015)** | Change failure rate less than 15% |
 
 ---
 
@@ -73,9 +73,9 @@ This is what we use as quality maturity levels.
 
 | **Item**          | **Description** |
 | :--               | :--             |
-| **[T015](catalog/test/T015)** | Requirement - Acceptance Test Mapping > 50%. |
-| **[E008](catalog/environment/E008)** | Data Migration Is Tested. |
-| **[D004](catalog/delivery/D004)** | Deployment Frequency Is On-Demand (Multiple Deploy Per Day). |
-| **[D008](catalog/delivery/D008)** | Lead Time For Changes Is Less Than One Hour. |
-| **[D012](catalog/delivery/D012)** | Time To Restore Service Is Less Than One Hour. |
-| **[E009](catalog/environment/E009)** | Ability To Automatic Data Migration Rollback. |
+| **[T015](catalog/test/T015)** | "Requirement - Acceptance Test" mapping coverage > 50% |
+| **[E008](catalog/environment/E008)** | Data migrations are tested |
+| **[D004](catalog/delivery/D004)** | Deployment is on-demand (multiple deploys per day) |
+| **[D008](catalog/delivery/D008)** | Lead time for changes is less than one hour |
+| **[D012](catalog/delivery/D012)** | Time to restore service is less than one hour |
+| **[E009](catalog/environment/E009)** | Data migration can be rolled back, automatically |


### PR DESCRIPTION
Recently, the titles were updated in items catalog; but the corresponding titles in maturity levels page were not updated.
There are also a few additional syntactical fixes.